### PR TITLE
Add ssm document capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Usage:
   -s   Pick a specific instance ID
   -h   Display this help
   -d   Specify the name of the ssm document to run. Only needed if running ssm document action.
-  -c   Values for the ssm document arguements (Optional)
+  -w   Values for the ssm document arguements (Optional)
   -g   The location in aws ssm parameter store of the github token to use (Optional)
+  -c   The name of the cloudwatch group to store logs in. Required for running documents.
   -v   Display version
   ```
 
@@ -60,8 +61,8 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 5. Run SSM Document named shell-script on shopify with default profile and arguments 'param1 param 2'. Document is required, github token is only required for private repos: 
 
-`aws-connect -x instance -r region -p default -a document -d shell-script -p default -c 'param1 "param 2"' -g /devops/github_token` 
+`aws-connect -x instance -r region -p default -a document -d shell-script -p default -w 'param1 "param 2"' -g /devops/github_token -c ssm-cloudwatch-logs` 
 
 6. Run SSM Document named shell-script on shopify with default profile and no arguements on a public repo: 
 
-`aws-connect -x instance -r region -p default -a document -d shell-script -p default` 
+`aws-connect -x instance -r region -p default -a document -d shell-script -p default -c ssm-cloudwatch-logs` 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 `aws-connect -s -t CLUSTER=prod`
 
-5. Run SSM Document named shell-script on instance-id i-23323ere3423 with default profile and arguments 'param1 param 2'. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required, github token is only required for private repos: 
+5. Run SSM Document named shell-script on instance-id i-23323ere3423 in region us-east-1 with default profile and arguments 'param1 param 2'. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required, github token is only required for private repos: 
 
-`aws-connect -x i-23323ere3423 -r region -p default -a document -d shell-script -p default -w 'param1 "param 2"' -g /devops/github_token -c ssm-cloudwatch-logs` 
+`aws-connect -x i-23323ere3423 -r us-east-1 -a document -d shell-script -p default -w 'param1 "param 2"' -g /devops/github_token -c ssm-cloudwatch-logs` 
 
-6. Run SSM Document named shell-script on instance-id i-23323ere3423 with default profile and no arguments on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required: 
+6. Run SSM Document named shell-script on instance-id i-23323ere3423 in region us-east-1 with staging profile and no arguments on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required: 
 
-`aws-connect -x i-23323ere3423 -r region -p default -a document -d shell-script -p default -c ssm-cloudwatch-logs` 
+`aws-connect -x i-23323ere3423 -r us-east-1 -a document -d shell-script -p staging -c ssm-cloudwatch-logs` 
 
 ## Sample Document
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Usage:
   -d   Specify the name of the ssm document to run. Only needed if running ssm document action.
   -w   Values for the ssm document arguements (Optional)
   -g   The location in aws ssm parameter store of the github token to use (Optional)
-  -c   The name of the cloudwatch group to store logs in. Required for running documents.
+  -c   The name of the cloudwatch group to store logs in. Required for running documents, defaults to aws-connect
   -v   Display version
   ```
 
@@ -59,10 +59,10 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 `aws-connect -s -t CLUSTER=prod`
 
-5. Run SSM Document named shell-script on shopify with default profile and arguments 'param1 param 2'. Document is required, github token is only required for private repos: 
+5. Run SSM Document named shell-script on shopify with default profile and arguments 'param1 param 2'. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required, github token is only required for private repos: 
 
 `aws-connect -x instance -r region -p default -a document -d shell-script -p default -w 'param1 "param 2"' -g /devops/github_token -c ssm-cloudwatch-logs` 
 
-6. Run SSM Document named shell-script on shopify with default profile and no arguements on a public repo: 
+6. Run SSM Document named shell-script on shopify with default profile and no arguements on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required: 
 
 `aws-connect -x instance -r region -p default -a document -d shell-script -p default -c ssm-cloudwatch-logs` 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage:
   -s   Pick a specific instance ID
   -h   Display this help
   -d   Specify the name of the ssm document to run. Only needed if running ssm document action.
-  -w   Values for the ssm document arguements (Optional)
+  -w   Values for the ssm document arguments (Optional)
   -g   The location in aws ssm parameter store of the github token to use (Optional)
   -c   The name of the cloudwatch group to store logs in. Required for running documents, defaults to aws-connect
   -v   Display version
@@ -63,6 +63,6 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 `aws-connect -x instance -r region -p default -a document -d shell-script -p default -w 'param1 "param 2"' -g /devops/github_token -c ssm-cloudwatch-logs` 
 
-6. Run SSM Document named shell-script on shopify with default profile and no arguements on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required: 
+6. Run SSM Document named shell-script on shopify with default profile and no arguments on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required: 
 
 `aws-connect -x instance -r region -p default -a document -d shell-script -p default -c ssm-cloudwatch-logs` 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Wrapper script around AWS session manager to establish remote shell connections 
 ```bash
 Usage:
 
-/usr/local/bin/aws-connect -a ssh|tunnel [-n <instance name>|-t <instance tag>] [-r region] [-p profile name] [-o port] [-x instance id] [-s] [-h] [-v]
+/usr/local/bin/aws-connect [-a ssh|tunnel|document] [-d <document name>] [-c <document parameters>] [-g <github access token location>] [-n <instance name>|-t <instance tag>] [-r <region>] [-p <profile name>] [-o <port>] [-x <instance id>] [-s] [-h] [-v]
 
-  -a   Connect interactive session, establish ssh tunnel, or run an ssm document on an instance (default: ssh)
+  -a   Connect interactive session (ssh), establish tunnel (tunnel), or run an ssm document (document) on an instance (default: ssh)
   -n   Value for the Name tag of an EC2 instance
   -t   Specify a tag instead of a name. The tag can be 'key' or 'key=value'
   -r   AWS region (default: us-east-1)
@@ -18,9 +18,9 @@ Usage:
   -x   override Name tag and connect direct to given instance ID
   -s   Pick a specific instance ID
   -h   Display this help
-  -d   Specify the name of the ssm document to run
-  -c   Values for the ssm document parameters
-  -g   The location in ssm of the github token to use
+  -d   Specify the name of the ssm document to run. Only needed if running ssm document action.
+  -c   Values for the ssm document arguements (Optional)
+  -g   The location in aws ssm parameter store of the github token to use (Optional)
   -v   Display version
   ```
 
@@ -58,6 +58,10 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 `aws-connect -s -t CLUSTER=prod`
 
-5. Run SSM Document named shell-script on shopify with default profile and parameters 'param1 param 2'. Github token and document are required: 
+5. Run SSM Document named shell-script on shopify with default profile and arguments 'param1 param 2'. Document is required, github token is only required for private repos: 
 
-`aws-connect -x instance -r region -p default -a document -d shell-script -p default -c 'param1 "param 2"' -g <token_location>` 
+`aws-connect -x instance -r region -p default -a document -d shell-script -p default -c 'param1 "param 2"' -g /devops/github_token` 
+
+6. Run SSM Document named shell-script on shopify with default profile and no arguements on a public repo: 
+
+`aws-connect -x instance -r region -p default -a document -d shell-script -p default` 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 `aws-connect -x i-23323ere3423 -r us-east-1 -a document -d shell-script -p staging -c ssm-cloudwatch-logs` 
 
-## Sample Document
+## Sample Documents
 
 In this repo under the sample_documents folder there are 3 .yml files. These show samples of what an ssm document might look like for 3 different cases:
 - Running a script from a private github repo

--- a/README.md
+++ b/README.md
@@ -59,10 +59,17 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 `aws-connect -s -t CLUSTER=prod`
 
-5. Run SSM Document named shell-script on shopify with default profile and arguments 'param1 param 2'. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required, github token is only required for private repos: 
+5. Run SSM Document named shell-script on instance-id i-23323ere3423 with default profile and arguments 'param1 param 2'. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required, github token is only required for private repos: 
 
-`aws-connect -x instance -r region -p default -a document -d shell-script -p default -w 'param1 "param 2"' -g /devops/github_token -c ssm-cloudwatch-logs` 
+`aws-connect -x i-23323ere3423 -r region -p default -a document -d shell-script -p default -w 'param1 "param 2"' -g /devops/github_token -c ssm-cloudwatch-logs` 
 
-6. Run SSM Document named shell-script on shopify with default profile and no arguments on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required: 
+6. Run SSM Document named shell-script on instance-id i-23323ere3423 with default profile and no arguments on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required: 
 
-`aws-connect -x instance -r region -p default -a document -d shell-script -p default -c ssm-cloudwatch-logs` 
+`aws-connect -x i-23323ere3423 -r region -p default -a document -d shell-script -p default -c ssm-cloudwatch-logs` 
+
+## Sample Document
+
+In this repo under the sample_documents folder there are 3 .yml files. These show samples of what an ssm document might look like for 3 different cases:
+- Running a script from a private github repo
+- Running a script from a public github repo
+- Running an ssm document

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 `aws-connect -s -t CLUSTER=prod`
 
-5. Run SSM Document named shell-script on instance-id i-23323ere3423 in region us-east-1 with default profile and arguments 'param1 param 2'. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required, github token is only required for private repos: 
+5. Run SSM Document named shell-script on instance-id i-23323ere3423 in region us-east-1 with default profile and arguments 'param1 param 2'. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required, A github token is required if the SSM document is referencing content in a private github repo. See this [AWS blog post](https://aws.amazon.com/blogs/mt/run-scripts-stored-in-private-or-public-github-repositories-using-amazon-ec2-systems-manager/) on documents referencing private repos: 
 
 `aws-connect -x i-23323ere3423 -r us-east-1 -a document -d shell-script -p default -w 'param1 "param 2"' -g /devops/github_token -c ssm-cloudwatch-logs` 
 
-6. Run SSM Document named shell-script on instance-id i-23323ere3423 in region us-east-1 with staging profile and no arguments on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required: 
+6. Run SSM Document named shell-script on instance-id i-23323ere3423 in region us-east-1 with staging profile and no arguments on a public repo. The cloudwatch log name has been changed to ssm-cloudwatch-logs. Document is required but since the repo is public no github token is required: 
 
 `aws-connect -x i-23323ere3423 -r us-east-1 -a document -d shell-script -p staging -c ssm-cloudwatch-logs` 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Usage:
 
 /usr/local/bin/aws-connect -a ssh|tunnel [-n <instance name>|-t <instance tag>] [-r region] [-p profile name] [-o port] [-x instance id] [-s] [-h] [-v]
 
-  -a   Connect interactive session or establish ssh tunnel (default: ssh)
+  -a   Connect interactive session, establish ssh tunnel, or run an ssm document on an instance (default: ssh)
   -n   Value for the Name tag of an EC2 instance
   -t   Specify a tag instead of a name. The tag can be 'key' or 'key=value'
   -r   AWS region (default: us-east-1)
@@ -18,6 +18,9 @@ Usage:
   -x   override Name tag and connect direct to given instance ID
   -s   Pick a specific instance ID
   -h   Display this help
+  -d   Specify the name of the ssm document to run
+  -c   Values for the ssm document parameters
+  -g   The location in ssm of the github token to use
   -v   Display version
   ```
 
@@ -55,3 +58,6 @@ The SSH tunnel can then be used for things like connecting to an RDS database th
 
 `aws-connect -s -t CLUSTER=prod`
 
+5. Run SSM Document named shell-script on shopify with default profile and parameters 'param1 param 2'. Github token and document are required: 
+
+`aws-connect -x instance -r region -p default -a document -d shell-script -p default -c 'param1 "param 2"' -g <token_location>` 

--- a/aws-connect
+++ b/aws-connect
@@ -19,9 +19,12 @@ version() {
 usage() {
   echo "Usage:"
   echo ""
-  echo "$programname -a ssh|tunnel [-n <instance name>|-t <instance tag>] [-r region] [-p profile name] [-o port] [-x instance id] [-s] [-h] [-v]"
+  echo "$programname -a ssh|tunnel|document [-d document name] [-c document parameters] [-g github access token location] [-n <instance name>|-t <instance tag>] [-r region] [-p profile name] [-o port] [-x instance id] [-s] [-h] [-v]"
   echo ""
   echo "  -a   Connect interactive session or establish ssh tunnel (default: ssh)"
+  echo "  -d   Run an ssm document on a specified EC2 instance"
+  echo "  -c   Optional parameters if required to run an ssm document"
+  echo "  -g   Optional. The location of your github personal access token in aws ssm parameter store"
   echo "  -n   Value for the Name tag of an EC2 instance"
   echo "  -t   Specify a tag instead of a name. The tag can be 'key' or 'key=value'"
   echo "  -r   AWS region (default: us-east-1)"
@@ -63,7 +66,7 @@ get_instances_by_tag() {
 }
 
 # get the options and set flags
-while getopts "a:n:t:r:p:o:x:shv" OPTION; do
+while getopts "a:d:c:g:n:t:r:p:o:x:shv" OPTION; do
   case $OPTION in
   v)
     version
@@ -101,6 +104,15 @@ while getopts "a:n:t:r:p:o:x:shv" OPTION; do
   s)
     interactive_mode=1
     ;;
+  d)
+    document_name=$OPTARG
+    ;;
+  c)
+    document_parameters=$OPTARG
+    ;;
+  g)
+    github_token_location=$OPTARG
+    ;;      
   *)
     echo "Incorrect options provided"
     exit 1
@@ -193,7 +205,7 @@ if [ -z "${instance_id}" ]; then
   fi
 fi
 
-  # SSH or tunnel
+  # SSH, tunnel, or document
 if [ "${action}" == "ssh" ]; then
   echo "Establishing session manager connection to ${instance_name} (${instance_id})"
   aws ssm start-session \
@@ -208,6 +220,55 @@ elif [ "${action}" == "tunnel" ]; then
     --parameters "{\"portNumber\":[\"22\"],\"localPortNumber\":[\"${port}\"]}" \
     --region "${aws_region}" \
     --profile "${aws_profile}"
+elif [ "${action}" == "document" ]; then
+
+  if [ -z "${github_token_location}" ]
+  then
+    echo "No github token"
+    document_parameters="parameters='${document_parameters}'"
+  else
+    document_parameters="githubTokenLocation='${github_token_location}',parameters='${document_parameters}'"
+    echo "Github token found"
+  fi
+
+  echo "Running ${document_name} on instance ${instance_id}"
+  
+  sh_command_id=$( aws ssm send-command \
+    --instance-ids ${instance_id} \
+    --document-name "${document_name}" \
+    --comment "Document run using aws-connect" \
+    --output text \
+    --parameters "${document_parameters}" \
+    --region ${aws_region} \
+    --profile ${aws_profile} \
+    --query "Command.CommandId") 
+
+  output=$(aws ssm list-command-invocations \
+    --command-id ${sh_command_id} \
+    --details)
+
+  status=$(echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.Status')
+
+  # wait for the command to finish running before getting the output
+  while [ "$status" == "InProgress" ]
+  do
+    echo "Command still running..."
+    sleep 5
+
+    output=$(aws ssm list-command-invocations \
+      --command-id ${sh_command_id} \
+      --details)
+
+    status=$(echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.Status' )
+  done
+
+  if [ "$status" == "Failed" ]
+  then
+    echo "Command Failed!"
+  fi
+
+  echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.CommandPlugins' | jq -r '.[1]' | jq -r '.Output'
+
 else
   echo "Unknown action ${action} specified"
   usage

--- a/aws-connect
+++ b/aws-connect
@@ -246,14 +246,14 @@ elif [ "${action}" == "document" ]; then
 
   # create the send-command as a string so that parameters can be appended on if needed
   aws_command="aws ssm send-command \
---instance-ids ${instance_id} \
---document-name \"${document_name}\" \
---comment \"Document run using aws-connect\" \
---output text \
---region ${aws_region} \
---profile ${aws_profile} \
---cloud-watch-output-config '{\"CloudWatchLogGroupName\":\"${cloudwatch_group}\",\"CloudWatchOutputEnabled\":true}' \
---query \"Command.CommandId\""
+    --instance-ids ${instance_id} \
+    --document-name \"${document_name}\" \
+    --comment \"Document run using aws-connect\" \
+    --output text \
+    --region ${aws_region} \
+    --profile ${aws_profile} \
+    --cloud-watch-output-config '{\"CloudWatchLogGroupName\":\"${cloudwatch_group}\",\"CloudWatchOutputEnabled\":true}' \
+    --query \"Command.CommandId\""
 
   if [ -n "${arguments}" ]; then
     aws_command="${aws_command} --parameters ${arguments}"
@@ -313,23 +313,17 @@ elif [ "${action}" == "document" ]; then
     # check if the command has succeeded. If so then get the command output
     if [ "Success" == "${status}" ]; then
 
-      log_streams=$(aws logs describe-log-streams --log-group-name ${cloudwatch_group} --log-stream-name-prefix "${sh_command_id}/${instance_id}" --query "logStreams[*].logStreamName")
-
-      log_streams="${log_streams:1:${#log_streams}-2}"
+      log_streams=$(aws logs describe-log-streams --log-group-name ${cloudwatch_group} --log-stream-name-prefix "${sh_command_id}/${instance_id}" --output text --query "logStreams[*].logStreamName")
 
       for log in ${log_streams[@]}; do
 
-        log=${log%\",}
-        log=${log%\"}
-        log=${log#\"}
-
-        printf "$(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name "${log}" --query "events[0].message")\n\n"
+        echo $(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name ${log} --query "events[0].message")
+        printf "\n\n"
 
       done
 
-      printf "\n"
-      printf "Log output is limited to 1MB. For the full logs, visit https://console.aws.amazon.com/cloudwatch/home then \
-view the streams starting with '${sh_command_id}/${instance_id}/' under the log group ${cloudwatch_group}"
+      printf "Log output is limited to 1MB. For the full logs, visit: "
+      printf 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%s/$3FlogStreamNameFilter=%s/%s' "${cloudwatch_group}" "${sh_command_id}" "${instance_id}"
 
       endLoop="true"
     fi

--- a/aws-connect
+++ b/aws-connect
@@ -226,38 +226,49 @@ elif [ "${action}" == "tunnel" ]; then
     --profile "${aws_profile}"
 elif [ "${action}" == "document" ]; then
 
-  if [ -z "${github_token_location}" ]
-  then
-    echo "No github token provided - scripts referenced in SSM document must be in a public repo if no token is provided"
-  else
-    arguments="githubTokenLocation='${github_token_location}',"
+  if [ -n "${github_token_location}" ]; then
+    arguments="githubTokenLocation='${github_token_location}'"
   fi
 
-  if [ -z "${document_parameters}" ]
-  then
-    arguments="${arguments::${#arguments}-1}"
-  else
-    arguments="${arguments}parameters='${document_parameters}'"
+  if [ -n "${document_parameters}" ]; then
+    if [ -n "${arguments}" ]; then
+      arguments="${arguments},parameters='${document_parameters}'"
+    else
+      arguments="parameters='${document_parameters}'"
+    fi
   fi
 
-  if [ -z "${cloudwatch_group}" ]
-  then
+  if [ -z "${cloudwatch_group}" ]; then
     cloudwatch_group="aws-connect"
   fi
 
-  echo "Running ${document_name} on instance ${instance_id}"
+  echo "Running ${document_name} on instance ${instance_id}"  
 
-  sh_command_id=$( aws ssm send-command \
-    --instance-ids ${instance_id} \
-    --document-name "${document_name}" \
-    --comment "Document run using aws-connect" \
-    --output text \
-    --parameters "${arguments}" \
-    --region ${aws_region} \
-    --profile ${aws_profile} \
-    --cloud-watch-output-config '{"CloudWatchLogGroupName":"'${cloudwatch_group}'","CloudWatchOutputEnabled":true}' \
-    --query "Command.CommandId")
+  # create the send-command as a string so that parameters can be appended on if needed
+  aws_command="aws ssm send-command \
+--instance-ids ${instance_id} \
+--document-name \"${document_name}\" \
+--comment \"Document run using aws-connect\" \
+--output text \
+--region ${aws_region} \
+--profile ${aws_profile} \
+--cloud-watch-output-config '{\"CloudWatchLogGroupName\":\"${cloudwatch_group}\",\"CloudWatchOutputEnabled\":true}' \
+--query \"Command.CommandId\""
 
+  if [ -n "${arguments}" ]; then
+    aws_command="${aws_command} --parameters ${arguments}"
+  fi
+
+  echo "Command to execute: ${aws_command}"
+
+  # execute the command
+  sh_command_id=$(eval $aws_command)
+
+  if [ "$?" != "0" ]; then
+    echo "Unable to execute command!"
+    exit 0
+  fi
+  # get the status of the command
   status=$(aws ssm list-command-invocations \
     --command-id "${sh_command_id}" \
     --details \
@@ -267,26 +278,64 @@ elif [ "${action}" == "document" ]; then
 
   echo "Command ID: $sh_command_id"
 
-  # wait for the command to finish running before getting the output
-  while [ "$status" == "InProgress" ]
-  do
+  ssm_failed_statuses=("Cancelled"
+  "Failed"
+  "Delivery Timed Out"
+  "Execution Timed Out"
+  "Failed"
+  "Invalid Platform"
+  "Undeliverable"
+  "Terminated"
+  "Access Denied"
+  "InvalidParameters")
+
+  # while the command has not failed or succeeded check the status every 5 seconds
+  endLoop="false"
+  while [ "${endLoop}" == "false" ]; do
+
     echo "Command still running..."
     sleep 5
-
+    
     status=$(aws ssm list-command-invocations \
       --command-id "${sh_command_id}" \
       --details \
       --output text \
       --no-paginate \
       --query "CommandInvocations[0].Status")  
+
+    # check if the command has failed
+    for (( i = 0; i < "${#ssm_failed_statuses[@]}"; i++ )); do
+      if [ "${ssm_failed_statuses[$i]}" == "${status}" ]; then
+        echo "Failure Status: ${ssm_failed_statuses[$i]}!"
+        endLoop="true"
+      fi
+    done
+
+    # check if the command has succeeded. If so then get the command output
+    if [ "Success" == "${status}" ]; then
+
+      log_streams=$(aws logs describe-log-streams --log-group-name ${cloudwatch_group} --log-stream-name-prefix "${sh_command_id}/${instance_id}" --query "logStreams[*].logStreamName")
+
+      log_streams="${log_streams:1:${#log_streams}-2}"
+
+      for log in ${log_streams[@]}; do
+
+        log=${log%\",}
+        log=${log%\"}
+        log=${log#\"}
+
+        printf "$(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name ${log} --query "events[0].message")\n\n"
+
+      done
+
+      echo "\n"
+      printf "Log output is limited to 1MB. For the full logs, visit https://console.aws.amazon.com/cloudwatch/home then \
+view the stream '${sh_command_id}/${instance_id}/' under the log group ${cloudwatch_group}"
+
+      endLoop="true"
+    fi
+
   done
-
-  if [ "$status" == "Failed" ]
-  then
-    echo "Command Failed!"
-  fi
-
-  printf "$(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name ${sh_command_id}/${instance_id}/runShellScript/stdout --query "events[0].message")"
 
 else
   echo "Unknown action ${action} specified"

--- a/aws-connect
+++ b/aws-connect
@@ -259,8 +259,6 @@ elif [ "${action}" == "document" ]; then
     aws_command="${aws_command} --parameters ${arguments}"
   fi
 
-  echo "Command to execute: ${aws_command}"
-
   # execute the command
   sh_command_id=$(eval $aws_command)
 
@@ -268,6 +266,9 @@ elif [ "${action}" == "document" ]; then
     echo "Unable to execute command!"
     exit 0
   fi
+
+  echo "Command ID: $sh_command_id"
+  
   # get the status of the command
   status=$(aws ssm list-command-invocations \
     --command-id "${sh_command_id}" \
@@ -275,8 +276,6 @@ elif [ "${action}" == "document" ]; then
     --output text \
     --no-paginate \
     --query "CommandInvocations[0].Status")
-
-  echo "Command ID: $sh_command_id"
 
   ssm_failed_statuses=("Cancelled"
   "Failed"
@@ -324,13 +323,13 @@ elif [ "${action}" == "document" ]; then
         log=${log%\"}
         log=${log#\"}
 
-        printf "$(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name ${log} --query "events[0].message")\n\n"
+        printf "$(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name "${log}" --query "events[0].message")\n\n"
 
       done
 
-      echo "\n"
+      printf "\n"
       printf "Log output is limited to 1MB. For the full logs, visit https://console.aws.amazon.com/cloudwatch/home then \
-view the stream '${sh_command_id}/${instance_id}/' under the log group ${cloudwatch_group}"
+view the streams starting with '${sh_command_id}/${instance_id}/' under the log group ${cloudwatch_group}"
 
       endLoop="true"
     fi

--- a/aws-connect
+++ b/aws-connect
@@ -25,7 +25,7 @@ usage() {
   echo "  -d   Specify the name of the ssm document to run. Only needed if running ssm document action."
   echo "  -w   Values for the ssm document arguements (Optional)"
   echo "  -g   The location in aws ssm parameter store of the github token to use (Optional)"
-  echo "  -c   The name of the cloudwatch group to store logs in. Required for running documents."
+  echo "  -c   The name of the cloudwatch group to store logs in. Required for running documents, defaults to aws-connect"
   echo "  -n   Value for the Name tag of an EC2 instance"
   echo "  -t   Specify a tag instead of a name. The tag can be 'key' or 'key=value'"
   echo "  -r   AWS region (default: us-east-1)"
@@ -238,6 +238,11 @@ elif [ "${action}" == "document" ]; then
     arguements="${arguements::${#arguements}-1}"
   else
     arguements="${arguements}parameters='${document_parameters}'"
+  fi
+
+  if [ -z "${cloudwatch_group}" ]
+  then
+    cloudwatch_group="aws-connect"
   fi
 
   echo "Running ${document_name} on instance ${instance_id}"

--- a/aws-connect
+++ b/aws-connect
@@ -23,7 +23,7 @@ usage() {
   echo ""
   echo "  -a   Connect interactive session (ssh), establish tunnel (tunnel), or run an ssm document (document) on an instance (default: ssh)"
   echo "  -d   Specify the name of the ssm document to run. Only needed if running ssm document action."
-  echo "  -w   Values for the ssm document arguements (Optional)"
+  echo "  -w   Values for the ssm document arguments (Optional)"
   echo "  -g   The location in aws ssm parameter store of the github token to use (Optional)"
   echo "  -c   The name of the cloudwatch group to store logs in. Required for running documents, defaults to aws-connect"
   echo "  -n   Value for the Name tag of an EC2 instance"
@@ -230,14 +230,14 @@ elif [ "${action}" == "document" ]; then
   then
     echo "No github token provided - scripts referenced in SSM document must be in a public repo if no token is provided"
   else
-    arguements="githubTokenLocation='${github_token_location}',"
+    arguments="githubTokenLocation='${github_token_location}',"
   fi
 
   if [ -z "${document_parameters}" ]
   then
-    arguements="${arguements::${#arguements}-1}"
+    arguments="${arguments::${#arguments}-1}"
   else
-    arguements="${arguements}parameters='${document_parameters}'"
+    arguments="${arguments}parameters='${document_parameters}'"
   fi
 
   if [ -z "${cloudwatch_group}" ]
@@ -252,7 +252,7 @@ elif [ "${action}" == "document" ]; then
     --document-name "${document_name}" \
     --comment "Document run using aws-connect" \
     --output text \
-    --parameters "${arguements}" \
+    --parameters "${arguments}" \
     --region ${aws_region} \
     --profile ${aws_profile} \
     --cloud-watch-output-config '{"CloudWatchLogGroupName":"'${cloudwatch_group}'","CloudWatchOutputEnabled":true}' \

--- a/aws-connect
+++ b/aws-connect
@@ -260,6 +260,8 @@ elif [ "${action}" == "document" ]; then
     --no-paginate \
     --query "CommandInvocations[0].Status")
 
+  echo "Command ID: $sh_command_id"
+
   # wait for the command to finish running before getting the output
   while [ "$status" == "InProgress" ]
   do

--- a/aws-connect
+++ b/aws-connect
@@ -19,12 +19,12 @@ version() {
 usage() {
   echo "Usage:"
   echo ""
-  echo "$programname -a ssh|tunnel|document [-d document name] [-c document parameters] [-g github access token location] [-n <instance name>|-t <instance tag>] [-r region] [-p profile name] [-o port] [-x instance id] [-s] [-h] [-v]"
+  echo "$programname [-a ssh|tunnel|document] [-d <document name>] [-c <document parameters>] [-g <github access token location>] [-n <instance name>|-t <instance tag>] [-r <region>] [-p <profile name>] [-o <port>] [-x <instance id>] [-s] [-h] [-v]"
   echo ""
-  echo "  -a   Connect interactive session or establish ssh tunnel (default: ssh)"
-  echo "  -d   Run an ssm document on a specified EC2 instance"
-  echo "  -c   Optional parameters if required to run an ssm document"
-  echo "  -g   Optional. The location of your github personal access token in aws ssm parameter store"
+  echo "  -a   Connect interactive session (ssh), establish tunnel (tunnel), or run an ssm document (document) on an instance (default: ssh)"
+  echo "  -d   Specify the name of the ssm document to run. Only needed if running ssm document action."
+  echo "  -c   Values for the ssm document arguements (Optional)"
+  echo "  -g   The location in aws ssm parameter store of the github token to use (Optional)"
   echo "  -n   Value for the Name tag of an EC2 instance"
   echo "  -t   Specify a tag instead of a name. The tag can be 'key' or 'key=value'"
   echo "  -r   AWS region (default: us-east-1)"
@@ -224,11 +224,16 @@ elif [ "${action}" == "document" ]; then
 
   if [ -z "${github_token_location}" ]
   then
-    echo "No github token"
-    document_parameters="parameters='${document_parameters}'"
+    echo "No github token provided - scripts referenced in SSM document must be in a public repo if no token is provided"
   else
-    document_parameters="githubTokenLocation='${github_token_location}',parameters='${document_parameters}'"
-    echo "Github token found"
+    arguements="githubTokenLocation='${github_token_location}',"
+  fi
+
+  if [ -z "${document_parameters}" ]
+  then
+    arguements=${arguements::${#arguements}-1}
+  else
+    arguements=$arguements"parameters='${document_parameters}'"
   fi
 
   echo "Running ${document_name} on instance ${instance_id}"
@@ -238,16 +243,17 @@ elif [ "${action}" == "document" ]; then
     --document-name "${document_name}" \
     --comment "Document run using aws-connect" \
     --output text \
-    --parameters "${document_parameters}" \
+    --parameters "${arguements}" \
     --region ${aws_region} \
     --profile ${aws_profile} \
-    --query "Command.CommandId") 
+    --query "Command.CommandId")
 
-  output=$(aws ssm list-command-invocations \
-    --command-id ${sh_command_id} \
-    --details)
-
-  status=$(echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.Status')
+  status=$(aws ssm list-command-invocations \
+    --command-id "${sh_command_id}" \
+    --details \
+    --output text \
+    --no-paginate \
+    --query "CommandInvocations[0].Status")
 
   # wait for the command to finish running before getting the output
   while [ "$status" == "InProgress" ]
@@ -255,11 +261,12 @@ elif [ "${action}" == "document" ]; then
     echo "Command still running..."
     sleep 5
 
-    output=$(aws ssm list-command-invocations \
-      --command-id ${sh_command_id} \
-      --details)
-
-    status=$(echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.Status' )
+    status=$(aws ssm list-command-invocations \
+      --command-id "${sh_command_id}" \
+      --details \
+      --output text \
+      --no-paginate \
+      --query "CommandInvocations[0].Status")  
   done
 
   if [ "$status" == "Failed" ]
@@ -267,7 +274,12 @@ elif [ "${action}" == "document" ]; then
     echo "Command Failed!"
   fi
 
-  echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.CommandPlugins' | jq -r '.[1]' | jq -r '.Output'
+  echo $(aws ssm list-command-invocations \
+    --command-id "${sh_command_id}" \
+    --details \
+    --output text \
+    --no-paginate \
+    --query "CommandInvocations[0].CommandPlugins[1].Output")
 
 else
   echo "Unknown action ${action} specified"

--- a/aws-connect
+++ b/aws-connect
@@ -281,7 +281,7 @@ elif [ "${action}" == "document" ]; then
     echo "Command Failed!"
   fi
 
-  echo $(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name ${sh_command_id}/${instance_id}/runShellScript/stdout --query "events[0].message")
+  printf "$(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name ${sh_command_id}/${instance_id}/runShellScript/stdout --query "events[0].message")"
 
 else
   echo "Unknown action ${action} specified"

--- a/aws-connect
+++ b/aws-connect
@@ -19,12 +19,12 @@ version() {
 usage() {
   echo "Usage:"
   echo ""
-  echo "$programname [-a ssh|tunnel|document] [-d <document name>] [-c <document parameters>] [-g <github access token location>] [-n <instance name>|-t <instance tag>] [-r <region>] [-p <profile name>] [-o <port>] [-x <instance id>] [-s] [-h] [-v]"
+  echo "$programname -a ssh|tunnel|document [-d document name] [-c document parameters] [-g github access token location] [-n <instance name>|-t <instance tag>] [-r region] [-p profile name] [-o port] [-x instance id] [-s] [-h] [-v]"
   echo ""
-  echo "  -a   Connect interactive session (ssh), establish tunnel (tunnel), or run an ssm document (document) on an instance (default: ssh)"
-  echo "  -d   Specify the name of the ssm document to run. Only needed if running ssm document action."
-  echo "  -c   Values for the ssm document arguements (Optional)"
-  echo "  -g   The location in aws ssm parameter store of the github token to use (Optional)"
+  echo "  -a   Connect interactive session or establish ssh tunnel (default: ssh)"
+  echo "  -d   Run an ssm document on a specified EC2 instance"
+  echo "  -c   Optional parameters if required to run an ssm document"
+  echo "  -g   Optional. The location of your github personal access token in aws ssm parameter store"
   echo "  -n   Value for the Name tag of an EC2 instance"
   echo "  -t   Specify a tag instead of a name. The tag can be 'key' or 'key=value'"
   echo "  -r   AWS region (default: us-east-1)"
@@ -224,16 +224,11 @@ elif [ "${action}" == "document" ]; then
 
   if [ -z "${github_token_location}" ]
   then
-    echo "No github token provided - scripts referenced in SSM document must be in a public repo if no token is provided"
+    echo "No github token"
+    document_parameters="parameters='${document_parameters}'"
   else
-    arguements="githubTokenLocation='${github_token_location}',"
-  fi
-
-  if [ -z "${document_parameters}" ]
-  then
-    arguements=${arguements::${#arguements}-1}
-  else
-    arguements=$arguements"parameters='${document_parameters}'"
+    document_parameters="githubTokenLocation='${github_token_location}',parameters='${document_parameters}'"
+    echo "Github token found"
   fi
 
   echo "Running ${document_name} on instance ${instance_id}"
@@ -243,17 +238,16 @@ elif [ "${action}" == "document" ]; then
     --document-name "${document_name}" \
     --comment "Document run using aws-connect" \
     --output text \
-    --parameters "${arguements}" \
+    --parameters "${document_parameters}" \
     --region ${aws_region} \
     --profile ${aws_profile} \
-    --query "Command.CommandId")
+    --query "Command.CommandId") 
 
-  status=$(aws ssm list-command-invocations \
-    --command-id "${sh_command_id}" \
-    --details \
-    --output text \
-    --no-paginate \
-    --query "CommandInvocations[0].Status")
+  output=$(aws ssm list-command-invocations \
+    --command-id ${sh_command_id} \
+    --details)
+
+  status=$(echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.Status')
 
   # wait for the command to finish running before getting the output
   while [ "$status" == "InProgress" ]
@@ -261,12 +255,11 @@ elif [ "${action}" == "document" ]; then
     echo "Command still running..."
     sleep 5
 
-    status=$(aws ssm list-command-invocations \
-      --command-id "${sh_command_id}" \
-      --details \
-      --output text \
-      --no-paginate \
-      --query "CommandInvocations[0].Status")  
+    output=$(aws ssm list-command-invocations \
+      --command-id ${sh_command_id} \
+      --details)
+
+    status=$(echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.Status' )
   done
 
   if [ "$status" == "Failed" ]
@@ -274,12 +267,7 @@ elif [ "${action}" == "document" ]; then
     echo "Command Failed!"
   fi
 
-  echo $(aws ssm list-command-invocations \
-    --command-id "${sh_command_id}" \
-    --details \
-    --output text \
-    --no-paginate \
-    --query "CommandInvocations[0].CommandPlugins[1].Output")
+  echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.CommandPlugins' | jq -r '.[1]' | jq -r '.Output'
 
 else
   echo "Unknown action ${action} specified"

--- a/aws-connect
+++ b/aws-connect
@@ -23,8 +23,9 @@ usage() {
   echo ""
   echo "  -a   Connect interactive session (ssh), establish tunnel (tunnel), or run an ssm document (document) on an instance (default: ssh)"
   echo "  -d   Specify the name of the ssm document to run. Only needed if running ssm document action."
-  echo "  -c   Values for the ssm document arguements (Optional)"
+  echo "  -w   Values for the ssm document arguements (Optional)"
   echo "  -g   The location in aws ssm parameter store of the github token to use (Optional)"
+  echo "  -c   The name of the cloudwatch group to store logs in. Required for running documents."
   echo "  -n   Value for the Name tag of an EC2 instance"
   echo "  -t   Specify a tag instead of a name. The tag can be 'key' or 'key=value'"
   echo "  -r   AWS region (default: us-east-1)"
@@ -66,7 +67,7 @@ get_instances_by_tag() {
 }
 
 # get the options and set flags
-while getopts "a:d:c:g:n:t:r:p:o:x:shv" OPTION; do
+while getopts "a:d:c:g:w:n:t:r:p:o:x:shv" OPTION; do
   case $OPTION in
   v)
     version
@@ -107,12 +108,15 @@ while getopts "a:d:c:g:n:t:r:p:o:x:shv" OPTION; do
   d)
     document_name=$OPTARG
     ;;
-  c)
+  w)
     document_parameters=$OPTARG
     ;;
   g)
     github_token_location=$OPTARG
     ;;      
+  c)
+    cloudwatch_group=$OPTARG
+    ;;
   *)
     echo "Incorrect options provided"
     exit 1
@@ -246,6 +250,7 @@ elif [ "${action}" == "document" ]; then
     --parameters "${arguements}" \
     --region ${aws_region} \
     --profile ${aws_profile} \
+    --cloud-watch-output-config '{"CloudWatchLogGroupName":"'${cloudwatch_group}'","CloudWatchOutputEnabled":true}' \
     --query "Command.CommandId")
 
   status=$(aws ssm list-command-invocations \
@@ -274,12 +279,7 @@ elif [ "${action}" == "document" ]; then
     echo "Command Failed!"
   fi
 
-  echo $(aws ssm list-command-invocations \
-    --command-id "${sh_command_id}" \
-    --details \
-    --output text \
-    --no-paginate \
-    --query "CommandInvocations[0].CommandPlugins[1].Output")
+  echo $(aws logs get-log-events --log-group-name ${cloudwatch_group} --log-stream-name ${sh_command_id}/${instance_id}/runShellScript/stdout --query "events[0].message")
 
 else
   echo "Unknown action ${action} specified"

--- a/aws-connect
+++ b/aws-connect
@@ -19,12 +19,12 @@ version() {
 usage() {
   echo "Usage:"
   echo ""
-  echo "$programname -a ssh|tunnel|document [-d document name] [-c document parameters] [-g github access token location] [-n <instance name>|-t <instance tag>] [-r region] [-p profile name] [-o port] [-x instance id] [-s] [-h] [-v]"
+  echo "$programname [-a ssh|tunnel|document] [-d <document name>] [-c <document parameters>] [-g <github access token location>] [-n <instance name>|-t <instance tag>] [-r <region>] [-p <profile name>] [-o <port>] [-x <instance id>] [-s] [-h] [-v]"
   echo ""
-  echo "  -a   Connect interactive session or establish ssh tunnel (default: ssh)"
-  echo "  -d   Run an ssm document on a specified EC2 instance"
-  echo "  -c   Optional parameters if required to run an ssm document"
-  echo "  -g   Optional. The location of your github personal access token in aws ssm parameter store"
+  echo "  -a   Connect interactive session (ssh), establish tunnel (tunnel), or run an ssm document (document) on an instance (default: ssh)"
+  echo "  -d   Specify the name of the ssm document to run. Only needed if running ssm document action."
+  echo "  -c   Values for the ssm document arguements (Optional)"
+  echo "  -g   The location in aws ssm parameter store of the github token to use (Optional)"
   echo "  -n   Value for the Name tag of an EC2 instance"
   echo "  -t   Specify a tag instead of a name. The tag can be 'key' or 'key=value'"
   echo "  -r   AWS region (default: us-east-1)"
@@ -224,30 +224,36 @@ elif [ "${action}" == "document" ]; then
 
   if [ -z "${github_token_location}" ]
   then
-    echo "No github token"
-    document_parameters="parameters='${document_parameters}'"
+    echo "No github token provided - scripts referenced in SSM document must be in a public repo if no token is provided"
   else
-    document_parameters="githubTokenLocation='${github_token_location}',parameters='${document_parameters}'"
-    echo "Github token found"
+    arguements="githubTokenLocation='${github_token_location}',"
+  fi
+
+  if [ -z "${document_parameters}" ]
+  then
+    arguements="${arguements::${#arguements}-1}"
+  else
+    arguements="${arguements}parameters='${document_parameters}'"
   fi
 
   echo "Running ${document_name} on instance ${instance_id}"
-  
+
   sh_command_id=$( aws ssm send-command \
     --instance-ids ${instance_id} \
     --document-name "${document_name}" \
     --comment "Document run using aws-connect" \
     --output text \
-    --parameters "${document_parameters}" \
+    --parameters "${arguements}" \
     --region ${aws_region} \
     --profile ${aws_profile} \
-    --query "Command.CommandId") 
+    --query "Command.CommandId")
 
-  output=$(aws ssm list-command-invocations \
-    --command-id ${sh_command_id} \
-    --details)
-
-  status=$(echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.Status')
+  status=$(aws ssm list-command-invocations \
+    --command-id "${sh_command_id}" \
+    --details \
+    --output text \
+    --no-paginate \
+    --query "CommandInvocations[0].Status")
 
   # wait for the command to finish running before getting the output
   while [ "$status" == "InProgress" ]
@@ -255,11 +261,12 @@ elif [ "${action}" == "document" ]; then
     echo "Command still running..."
     sleep 5
 
-    output=$(aws ssm list-command-invocations \
-      --command-id ${sh_command_id} \
-      --details)
-
-    status=$(echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.Status' )
+    status=$(aws ssm list-command-invocations \
+      --command-id "${sh_command_id}" \
+      --details \
+      --output text \
+      --no-paginate \
+      --query "CommandInvocations[0].Status")  
   done
 
   if [ "$status" == "Failed" ]
@@ -267,7 +274,12 @@ elif [ "${action}" == "document" ]; then
     echo "Command Failed!"
   fi
 
-  echo $output | jq -r '.[]' | jq -r '.[]' | jq -r '.CommandPlugins' | jq -r '.[1]' | jq -r '.Output'
+  echo $(aws ssm list-command-invocations \
+    --command-id "${sh_command_id}" \
+    --details \
+    --output text \
+    --no-paginate \
+    --query "CommandInvocations[0].CommandPlugins[1].Output")
 
 else
   echo "Unknown action ${action} specified"

--- a/sample_documents/private_repo_script.yml
+++ b/sample_documents/private_repo_script.yml
@@ -1,0 +1,45 @@
+---
+  schemaVersion: "2.2"
+  description: "Run Github script"
+  parameters:
+    githubTokenLocation:
+      type: "String"
+      description: "Location in ssm param store of your github token"
+      default: "none"
+    workingDirectory:
+      type: "String"
+      default: ""
+      description: "(Optional) The path where the content will be downloaded and executed\
+        \ from on your instance."
+      maxChars: 4096
+    executionTimeout:
+      description: "(Optional) The time in seconds for a command to complete before\
+        \ it is considered to have failed. Default is 3600 (1 hour). Maximum is 28800\
+        \ (8 hours)."
+      type: "String"
+      default: "3600"
+      allowedPattern: "([1-9][0-9]{0,3})|(1[0-9]{1,4})|(2[0-7][0-9]{1,3})|(28[0-7][0-9]{1,2})|(28800)"
+    parameters:
+      type: "String"
+      default: ""
+      description: "(Optional) Parameters to be passed to the script. These are positional."
+  mainSteps:
+  - action: "aws:downloadContent"
+    name: "downloadContent"
+    inputs:
+      sourceType: "GitHub"
+      sourceInfo: "{\"owner\":\"$REPO_OWNER\", \"repository\":\"$REPO_NAME\",\"getOptions\" : \"branch:main\",\"path\" :\"$filePath/\", \"tokenInfo\":\"{{ ssm-secure:{{githubTokenLocation}} }}\"}"
+      destinationPath: "{{ workingDirectory }}"
+  - precondition:
+      StringEquals:
+      - "platformType"
+      - "Linux"
+    action: "aws:runShellScript"
+    name: "runShellScript"
+    inputs:
+      runCommand:
+        - 'cp $fileName /'
+        - sudo -i bash -c '/$fileName {{ parameters }}'
+        - sudo -i bash -c 'rm /$fileName'
+      workingDirectory: "{{ workingDirectory }}"
+      timeoutSeconds: "{{ executionTimeout }}"

--- a/sample_documents/public_repo_script.yml
+++ b/sample_documents/public_repo_script.yml
@@ -1,0 +1,41 @@
+---
+  schemaVersion: "2.2"
+  description: "Run Github script"
+  parameters:
+    workingDirectory:
+      type: "String"
+      default: ""
+      description: "(Optional) The path where the content will be downloaded and executed\
+        \ from on your instance."
+      maxChars: 4096
+    executionTimeout:
+      description: "(Optional) The time in seconds for a command to complete before\
+        \ it is considered to have failed. Default is 3600 (1 hour). Maximum is 28800\
+        \ (8 hours)."
+      type: "String"
+      default: "3600"
+      allowedPattern: "([1-9][0-9]{0,3})|(1[0-9]{1,4})|(2[0-7][0-9]{1,3})|(28[0-7][0-9]{1,2})|(28800)"
+    parameters:
+      type: "String"
+      default: ""
+      description: "(Optional) Parameters to be passed to the script. These are positional."
+  mainSteps:
+  - action: "aws:downloadContent"
+    name: "downloadContent"
+    inputs:
+      sourceType: "GitHub"
+      sourceInfo: "{\"owner\":\"$REPO_OWNER\", \"repository\":\"$REPO_NAME\",\"getOptions\" : \"branch:main\",\"path\" :\"$filePath/\"}"
+      destinationPath: "{{ workingDirectory }}"
+  - precondition:
+      StringEquals:
+      - "platformType"
+      - "Linux"
+    action: "aws:runShellScript"
+    name: "runShellScript"
+    inputs:
+      runCommand:
+        - 'cp $fileName /'
+        - sudo -i bash -c '/$fileName {{ parameters }}'
+        - sudo -i bash -c 'rm /$fileName'
+      workingDirectory: "{{ workingDirectory }}"
+      timeoutSeconds: "{{ executionTimeout }}"

--- a/sample_documents/ssm_script.yml
+++ b/sample_documents/ssm_script.yml
@@ -1,0 +1,34 @@
+---
+  schemaVersion: "2.2"
+  description: "Run Github script"
+  parameters:
+    workingDirectory:
+      type: "String"
+      default: ""
+      description: "(Optional) The path where the content will be downloaded and executed\
+        \ from on your instance."
+      maxChars: 4096
+    executionTimeout:
+      description: "(Optional) The time in seconds for a command to complete before\
+        \ it is considered to have failed. Default is 3600 (1 hour). Maximum is 28800\
+        \ (8 hours)."
+      type: "String"
+      default: "3600"
+      allowedPattern: "([1-9][0-9]{0,3})|(1[0-9]{1,4})|(2[0-7][0-9]{1,3})|(28[0-7][0-9]{1,2})|(28800)"
+    parameters:
+      type: "String"
+      default: ""
+      description: "(Optional) Parameters to be passed to the script. These are positional."
+  mainSteps:
+  - precondition:
+      StringEquals:
+      - "platformType"
+      - "Linux"
+    action: "aws:runShellScript"
+    name: "runShellScript"
+    inputs:
+      runCommand:
+        - echo 'Hello World!'
+        - echo {{ parameters }}
+      workingDirectory: "{{ workingDirectory }}"
+      timeoutSeconds: "{{ executionTimeout }}"


### PR DESCRIPTION
- Add ssm document capability
- Updated readme

SSM documents can now be run on instances without having to enter the instance. Only persons with permissions for the document will be able to execute the file on the instance.