### PR TITLE
Update tag-and-release.yml

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -35,7 +35,6 @@ jobs:
     - name: Create Relase TAR
       id: create_tar
       run: |
-        mv aws-connect.sh aws-connect
         tar cvzf ./aws-connect-${{steps.get_version.outputs.version}}.tar.gz aws-connect* README.md
   
     - name: Generate Checksum


### PR DESCRIPTION
removed a step from the github action to create the tar. The aws-connect file is not named aws-connect.sh so there is no need to rename it. This seems to cause the github action to fail