### PR TITLE
Allows passing a document name for SSH sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage:
   -x   override Name tag and connect direct to given instance ID
   -s   Pick a specific instance ID
   -h   Display this help
-  -d   Specify the name of the ssm document to run. Only needed if running ssm document action.
+  -d   Specify the name of the ssm document to run.
   -w   Values for the ssm document arguments (Optional)
   -g   The location in aws ssm parameter store of the github token to use (Optional)
   -c   The name of the cloudwatch group to store logs in. Required for running documents, defaults to aws-connect

--- a/aws-connect
+++ b/aws-connect
@@ -215,15 +215,15 @@ fi
   # SSH, tunnel, or document
 if [ "${action}" == "ssh" ]; then
   echo "Establishing session manager connection to ${instance_name} (${instance_id})"
-  if [ -n "${document_name}" ]; then
+  if [ -z "${document_name}" ]; then
     aws ssm start-session \
       --target "${instance_id}" \
-      --document-name "${document_name}" \
       --region "${aws_region}" \
       --profile "${aws_profile}"
   else
     aws ssm start-session \
       --target "${instance_id}" \
+      --document-name "${document_name}" \
       --region "${aws_region}" \
       --profile "${aws_profile}"
   fi

--- a/aws-connect
+++ b/aws-connect
@@ -218,12 +218,12 @@ if [ "${action}" == "ssh" ]; then
   if [ -n "${document_name}" ]; then
     aws ssm start-session \
       --target "${instance_id}" \
+      --document-name "${document_name}" \
       --region "${aws_region}" \
       --profile "${aws_profile}"
   else
     aws ssm start-session \
       --target "${instance_id}" \
-      --document-name "${document_name}" \
       --region "${aws_region}" \
       --profile "${aws_profile}"
   fi

--- a/aws-connect
+++ b/aws-connect
@@ -215,10 +215,18 @@ fi
   # SSH, tunnel, or document
 if [ "${action}" == "ssh" ]; then
   echo "Establishing session manager connection to ${instance_name} (${instance_id})"
-  aws ssm start-session \
-    --target "${instance_id}" \
-    --region "${aws_region}" \
-    --profile "${aws_profile}"
+  if [ -n "${document_name}" ]; then
+    aws ssm start-session \
+      --target "${instance_id}" \
+      --region "${aws_region}" \
+      --profile "${aws_profile}"
+  else
+    aws ssm start-session \
+      --target "${instance_id}" \
+      --document-name "${document_name}" \
+      --region "${aws_region}" \
+      --profile "${aws_profile}"
+  fi
 elif [ "${action}" == "tunnel" ]; then
   echo "Creating SSH tunnel to ${tag_value} (${instance_id})"
   aws ssm start-session \


### PR DESCRIPTION
As discussed in https://github.com/rewindio/aws-connect/issues/8, this would allow passing the document name for an interactive SSH session. Would help us as we use documents to impersonate different users.