### PR TITLE
Search PATH for bash

### DIFF
--- a/aws-connect
+++ b/aws-connect
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Wrapper around AWS session manager for instance access and SSH tunnels
 


### PR DESCRIPTION
bash is not always in `/bin`.
 
`#!/usr/bin/env` searches `PATH` for bash.

This increases portability.