### PR TITLE
Use default profile region if no profile given

### DIFF
--- a/aws-connect
+++ b/aws-connect
@@ -173,6 +173,10 @@ if [ -z "${aws_region:+x}" ]; then
   fi
 
   if [ -z "${aws_region:+x}" ]; then
+    aws_region=$(aws configure get region)
+  fi
+
+  if [ -z "${aws_region:+x}" ]; then
     aws_region="${AWS_REGION}"
   fi
 


### PR DESCRIPTION
If no region or profile are passed via flags, this makes an addition check to the default profile before falling back to environment and in-built default (us-east-1)

```ini
// ~/.aws/config
[default]
region = eu-west-2
```

```
$ aws-connect -n "test"
... will attempt to connect using eu-west-2 rather than us-east-1
```