### PR TITLE
Update calls to set-output in GHA

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -17,8 +17,8 @@ jobs:
       id: get_version
       run: |
         version=$(grep "^version=" aws-connect |cut -f2 -d"=")
-        echo ::set-output name=version::$version
-        echo ::set-output name=version_tag::v$version
+        echo version=$version >> $GITHUB_OUTPUT
+        echo version_tag=v$version >> $GITHUB_OUTPUT
 
     - name: Tag commit
       uses: tvdias/github-tagger@v0.0.1


### PR DESCRIPTION
`set-output` is set to be deprecated in 2023.
This change migrates calls to set-output to using
the GITHUB_OUTPUT env file instead as per GH's
recommendation.