### PR TITLE
ssh: filter instances by PingStatus to ensure only get online instances

### DIFF
--- a/aws-connect
+++ b/aws-connect
@@ -79,7 +79,7 @@ get_instance_by_ssm_name() {
 
   instance_id=$(aws ssm describe-instance-information \
     --filters "Key=tag:Name,Values=${name}" \
-    --query 'InstanceInformationList[*].{Instance:InstanceId,Name:Name}' \
+    --query 'InstanceInformationList[?PingStatus==`Online`].{Instance:InstanceId,Name:Name,Status:PingStatus}' \
     --output json \
     --region "${region}" \
     --profile "${profile}" | jq -r '.[0].Instance')


### PR DESCRIPTION
## Summary
Filter SSM instances by PingStatus to ensure only online instances are selected

## Details
Added a condition to the `aws ssm describe-instance-information` query to filter instances where `PingStatus` is `Online`.
This change ensures the retrieved instance ID corresponds to an active and reachable instance.
This change helps to avoid selecting offlineinstances.

## Testing
By using the `-m` flag, If exists two instances with the same tag Name, gets the first one, and try to connect to it, but if this instance is not online, fails:

```
aws ssm describe-instance-information \
    --filters "Key=tag:Name,Values=${name}" \
    --query 'InstanceInformationList[*].{Instance:InstanceId,Name:Name,Status:PingStatus}' \
    --output json \
    --region ${region} \
    --profile ${profile} | jq

[
  {
    "Instance": "mi-00e112345678",
    "Name": "instance-01",
    "Status": "ConnectionLost"
  },
  {
    "Instance": "mi-00e987654321",
    "Name": "instance-01",
    "Status": "Online"
  }
]
```
