### PR TITLE
fix(): fix regression when using -t or -n (tags, Name tag) when connecting to instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## [1.0.24]
+## [1.1.1]
+
+- @mkhinda29 Fix regression when using -t (tags) or -n (Name tag)
+
+## [1.1.0]
 
 - @andreclaro add AWS System Manager support to connect to non-EC2 instances using their Name tag (use of `-m` flag)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.1.1]
 
+- @qedgardo ssh: filter instances by PingStatus to ensure only get online instances #26
 - @mkhinda29 Fix regression when using -t (tags) or -n (Name tag)
 
 ## [1.1.0]

--- a/aws-connect
+++ b/aws-connect
@@ -3,7 +3,7 @@
 # Wrapper around AWS session manager for instance access and SSH tunnels
 
 programname=$0
-version=1.1.0
+version=1.1.1
 
 # Defaults
 action=ssh
@@ -215,8 +215,8 @@ if [ -n "${instance_id}" ] && [ -n "${ssm_name}" ]; then
   exit 1
 fi
 
-if [ -n "${instance_id}" ]; then
-  echo "Instance ID: ${instance_id}"
+if [ -n "${tag_value}" ]; then
+  echo "Instance Name Tag: ${tag_value}"
   instance_ids=$(get_instances_by_tag "${tag_value}" "${aws_region}" "${aws_profile}")
 fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-connect",
-  "version": "1.0.24",
+  "version": "1.1.1",
   "description": "Wrapper script around AWS session manager to establish remote shell connections or SSH tunnels",
   "scripts": ["aws-connect"],
   "global": "true",


### PR DESCRIPTION
- #24 introduced a small regression when using aws-connect to connect to an instance using a tag or specifically the Name tag.

Using -m "ssm-name" works OK.

ex:
```
./aws-connect -p staging -r us-east-1 -n 'my-ec2-instance'
./aws-connect -p staging -r us-east-1 -t Name='my-ec2-instance'

No instances available with tag Name=my-ec2-instance in region us-east-1
Establishing session manager connection to  ()

Parameter validation failed:
Invalid length for parameter Target, value: 0, valid min length: 1
```

Fix is to allow the lookup by tag to happen as it did in v1.0.23.

Tested by running and connecting using the 4 instance identifiers
```
./aws-connect -p staging -r us-east-1 -n 'my-ec2-instance'
./aws-connect -p staging -r us-east-1 -t Name='my-ec2-instance'
./aws-connect -p staging -r us-east-1 -m 'my-ec2-instance'
./aws-connect -p staging -r us-east-1 -x 'i-021d9e7fe3eca6013'
```