### PR TITLE
chore(): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "appsec"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "patch"
+        - "minor"

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -11,43 +11,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
-    - name: Get version
-      id: get_version
-      run: |
-        version=$(grep "^version=" aws-connect |cut -f2 -d"=")
-        echo version=$version >> $GITHUB_OUTPUT
-        echo version_tag=v$version >> $GITHUB_OUTPUT
+      - name: Get version
+        id: get_version
+        run: |
+          version=$(grep "^version=" aws-connect |cut -f2 -d"=")
+          echo version=$version >> $GITHUB_OUTPUT
+          echo version_tag=v$version >> $GITHUB_OUTPUT
 
-    - name: Tag commit
-      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        tag: "${{steps.get_version.outputs.version_tag}}"
+      - name: Tag commit
+        uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{steps.get_version.outputs.version_tag}}"
 
-    - name: Extract from changelog
-      id: extract_changes
-      run: |
-        # Must use a temporary file or it loses the formatting
-        VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
+      - name: Extract from changelog
+        id: extract_changes
+        run: |
+          # Must use a temporary file or it loses the formatting
+          VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
 
-    - name: Create Relase TAR
-      id: create_tar
-      run: |
-        tar cvzf ./aws-connect-${{steps.get_version.outputs.version}}.tar.gz aws-connect* README.md
+      - name: Create Relase TAR
+        id: create_tar
+        run: |
+          tar cvzf ./aws-connect-${{steps.get_version.outputs.version}}.tar.gz aws-connect* README.md
 
-    - name: Generate Checksum
-      id: generate_checksum
-      run: |
-        checksum=$(sha256sum ./aws-connect-${{steps.get_version.outputs.version}}.tar.gz | awk '{print $1}')
-        echo "${checksum}" > sha256.sum
-        echo "SHA256: ${checksum}" >> REL-BODY.md
+      - name: Generate Checksum
+        id: generate_checksum
+        run: |
+          checksum=$(sha256sum ./aws-connect-${{steps.get_version.outputs.version}}.tar.gz | awk '{print $1}')
+          echo "${checksum}" > sha256.sum
+          echo "SHA256: ${checksum}" >> REL-BODY.md
 
-    - name: Create Release
-      uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
-      with:
-        tag: ${{steps.get_version.outputs.version_tag}}
-        artifacts: "*.gem, CHANGELOG.md, sha256.sum, aws-connect*.tar.gz"
-        bodyFile: "REL-BODY.md"
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
+        with:
+          tag: ${{steps.get_version.outputs.version_tag}}
+          artifacts: "*.gem, CHANGELOG.md, sha256.sum, aws-connect*.tar.gz"
+          bodyFile: "REL-BODY.md"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pin GitHub Actions to commit SHAs

## Description of change

Pins all third-party GitHub Actions to specific commit SHAs to protect
against tag hijacking / supply chain attacks. Actions from the `rewindio`
org are excluded and remain at their original version refs.

Uses [ratchet](https://github.com/sethvargo/ratchet) for SHA resolution.

## Testing Performed
